### PR TITLE
Allowing different wordpress-develop versions if other than latest WP

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -76,9 +76,9 @@ install_test_suite() {
       if [ $WP_VERSION == 'latest' ]; then
         local TEST_BRANCH_NAME='trunk'
       else
-        local TEST_BRANCH_NAME=$(sed 's/\([0-9]*\.[0-9]*\).*/\1/' <<< $WP_VERSION)
+        local TEST_BRANCH_NAME='branches/'$(sed 's/\([0-9]*\.[0-9]*\).*/\1/' <<< $WP_VERSION)
       fi
-    svn co --quiet http://develop.svn.wordpress.org/branches/${TEST_BRANCH_NAME}/tests/phpunit/includes/ $WP_TESTS_DIR
+    svn co --quiet http://develop.svn.wordpress.org/${TEST_BRANCH_NAME}/tests/phpunit/includes/ $WP_TESTS_DIR
   fi
 
   cd $WP_TESTS_DIR

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -72,7 +72,13 @@ install_test_suite() {
   if [ ! "$(ls -A $WP_TESTS_DIR)" ]; then
     # set up testing suite
     mkdir -p $WP_TESTS_DIR
-    svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/ $WP_TESTS_DIR
+      #if latest, use trunk develop version, if not, use major version
+      if [ $WP_VERSION == 'latest' ]; then
+        local TEST_BRANCH_NAME='trunk'
+      else
+        local TEST_BRANCH_NAME=$(sed 's/\([0-9]*\.[0-9]*\).*/\1/' <<< $WP_VERSION)
+      fi
+    svn co --quiet http://develop.svn.wordpress.org/branches/${TEST_BRANCH_NAME}/tests/phpunit/includes/ $WP_TESTS_DIR
   fi
 
   cd $WP_TESTS_DIR


### PR DESCRIPTION
I've encountered an issue - If I am specifying other WP version, the script is still using the latest WP dev version (i.e. trunk) and not the proper version. For example, if I want to test version 4.3, I don't want to use `http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/` but to use `http://develop.svn.wordpress.org/branches/4.3/tests/phpunit/includes/`. My fix is taking the version, if it is latest, use 'trunk' if not, use the proper branch. If a minor version is used (4.3.1), I am removing the minor version.

If I am using trunk all the time, it can leads to issues like this https://core.trac.wordpress.org/ticket/33888

You can see the script in action in one my WP plugin here: https://travis-ci.org/barzik/wp-notice/builds/80667833
