### PR TITLE
Feature/add phpcs script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,6 @@ before_script:
   - bash wp-tests/bin/install-wp-tests.sh test root '' localhost $WP_VERSION
 
 script:
+  - phpcs --standard=WordPress ./**/*.php
   - phpunit
   - cd tests/rspec && bundle exec rspec test.rb

--- a/README.md
+++ b/README.md
@@ -134,3 +134,41 @@ script:
   - phpunit
 ```
 
+### Example of validating WordPress PHP coding standards 
+1. Copy spec/ folder from this repo into your repo root
+2. Add this into your .travis.yml
+
+```yaml
+# This uses newer and faster docker based build system
+sudo: false
+
+language: php
+
+notifications:
+  on_success: never
+  on_failure: change
+
+php:
+  - nightly # PHP 7.0
+  - 5.6
+  - 5.5
+  - 5.4
+
+env:
+  - WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:12000 WP_TEST_USER=test WP_TEST_USER_PASS=test
+
+matrix:
+  allow_failures:
+    - php: nightly
+
+before_script:
+  # Install composer packages before trying to activate themes or plugins
+  # - composer install
+
+  - git clone https://github.com/Koodimonni/wordpress-test-template wp-tests
+  - bash wp-tests/bin/install-wp-tests.sh test root '' localhost $WP_VERSION
+
+script:
+  - phpcs --standard=WordPress ./**/*.php
+```
+

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -171,8 +171,6 @@ run_phpcs() {
   npm install -g jshint
   phpcs --config-set installed_paths $(pear config-get php_dir)/PHP/CodeSniffer/Standards/WordPress
   phpcs -i
-  local FOLDER_PATH=$(dirname $DIR)
-  cd $FOLDER_PATH
 }
 
 install_wp

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -163,6 +163,18 @@ start_server() {
   php -S 0.0.0.0:$WP_PORT router.php &
 }
 
+run_phpcs() {
+  pear config-set auto_discover 1
+  pear install PHP_CodeSniffer
+  git clone git://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $(pear config-get php_dir)/PHP/CodeSniffer/Standards/WordPress
+  phpenv rehash
+  npm install -g jshint
+  phpcs --config-set installed_paths $(pear config-get php_dir)/PHP/CodeSniffer/Standards/WordPress
+  phpcs -i
+  local FOLDER_PATH=$(dirname $DIR)
+  cd $FOLDER_PATH
+}
+
 install_wp
 install_test_suite
 install_db
@@ -170,3 +182,4 @@ install_real_wp
 link_this_project
 install_rspec_requirements
 start_server
+run_phpcs


### PR DESCRIPTION
Running phpcs WordPress code standards tests are nice feature that I am using in one of my plug-ins. The installation of PEAR phpcs package is in the install.sh and the execution is in the travis.yml.
